### PR TITLE
Fix XBox for XBox axes and Rumble values

### DIFF
--- a/examples/USBHost_viewer/USBHost_viewer.ino
+++ b/examples/USBHost_viewer/USBHost_viewer.ino
@@ -599,13 +599,23 @@ void tft_JoystickData() {
         x2_cur = user_axis[2];
         something_changed = true;
     }
-    if (user_axis[5] != y2_cur) {  //yR or z-axis
-        y2_cur = user_axis[5];
-        something_changed = true;
-    }
+
     //Rumble Axis
     switch (joystick.joystickType()) {
     case JoystickController::XBOXONE:
+      if (user_axis[3] != y2_cur) {  //yR or z-axis
+        y2_cur = user_axis[3];
+        something_changed = true;
+      }
+      if (user_axis[4] != L1_cur) {  //xR
+          L1_cur = user_axis[4];
+          something_changed = true;
+      }
+      if (user_axis[5] != R1_cur) {  //yR or z-axis
+          R1_cur = user_axis[5];
+          something_changed = true;
+      }
+        break;
     case JoystickController::XBOX360:
     case JoystickController::PS4:
         if (user_axis[3] != L1_cur) {  //xR


### PR DESCRIPTION
Made an update to fix the axes.  Had to change a few things:
in Joystick:
mapping went too: static const uint8_t xbox_bt_axis_order_mapping[] = { 0, 1, 2, 3, 4, 5};
and
int axis_value = (i < 4) ? (int)(uint16_t)xb1d->axis[i] : xb1d->axis[i];  //was i<2.  

in the sketch changed things around accodingly